### PR TITLE
IBMi systems pretend to be linux.

### DIFF
--- a/src/clojupyter/kernel/os.clj
+++ b/src/clojupyter/kernel/os.clj
@@ -15,6 +15,8 @@
     (os? "mac")		:macos
     (os? "linux")	:linux
     (os? "windows")	:windows
+    ;;pretend IBMi OS/400 is just plain old linux.
+    (os? "os/400") :linux
     true		nil))
 
 (defn supported-os?


### PR DESCRIPTION
Currently get "Not supported on OS/400" when trying to run on IBMi.   Trying to make it just work like it was a linux box.